### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.idea
+.git
+.gitignore
+.dockerignore
+.venv
+docker-data
+docker-compose.yml
+Dockerfile
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDEs
+.idea
+
 # Configuration file
 config.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.5-alpine
+
+ADD ./requirements.txt /app/requirements.txt
+RUN pip install -r /app/requirements.txt
+
+ADD . /app
+RUN cp /app/config.docker.py /app/config.py
+
+CMD python index.py
+WORKDIR /app
+EXPOSE 5000

--- a/config.docker.py
+++ b/config.docker.py
@@ -1,0 +1,29 @@
+import os
+
+
+DEBUG = os.getenv('DEBUG', 'False').lower() in ("yes", "true", "t", "1")
+
+# Redis configuration
+REDIS_HOST = os.getenv('REDIS_HOST', 'redis')
+REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))
+REDIS_DB = int(os.getenv('REDIS_DB', 0))
+REDIS_PASSWORD = os.getenv('REDIS_PASSWORD', None)
+
+# Untouched password entries will be deleted after this period (in seconds)
+TTL = int(os.getenv('TTL', 600))    # 10 min
+
+# APPLICATION SERVER
+APP_PORT = int(os.getenv('APP_PORT', 5000))
+APP_HOST = '0.0.0.0'
+
+# User Agent blacklist to prevent password withdrawal by bot (in lowercase)
+UA_BLACKLIST = [
+    'facebook',
+    'googlebot',
+    'slack'
+    'bot',
+    'external-hit',
+    'fetcher',
+    'twitterbot',
+    'telegrambot'
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  main:
+    build: .
+    restart: always
+    ports:
+      - 5000:5000
+    networks:
+      - internal
+      - public
+    depends_on:
+      - redis
+    environment:
+      - TTL=86400
+  redis:
+    image: redis:latest
+    restart: always
+    networks:
+      - internal
+    volumes:
+      - redis-persistent-data:/data
+
+volumes:
+  redis-persistent-data:
+
+networks:
+  internal:
+  public:

--- a/index.py
+++ b/index.py
@@ -22,7 +22,6 @@ r = redis.StrictRedis(
     password=config.REDIS_PASSWORD
 )
 
-
 @app.route('/set', methods=['post'])
 def set_pass():
     assert request.method == 'POST'
@@ -98,4 +97,4 @@ if __name__ == '__main__':
     except AttributeError:
         host = '127.0.0.1'
 
-    app.run(host=host, port=port)
+    app.run(host=host, port=port, debug=config.DEBUG)


### PR DESCRIPTION
You should create official docker-image on Docker Hub... then docker-compose.yml can be updated to use `image` and not `build` and after that, README should be also updated to write some examples how to use passion in container